### PR TITLE
Add ip resource support

### DIFF
--- a/examples/ip/README.md
+++ b/examples/ip/README.md
@@ -1,0 +1,64 @@
+# IP
+
+## Reserve a new adress
+
+To allocate a new adress specify the required values `datacenter`, `platform` and `version`.
+
+```
+$ cat ip.tf
+resource "glesys_ip" "example" {
+  datacenter = "Stockholm"
+  platform   = "KVM"
+  version    = 6
+}
+```
+
+Changing any of these values will release the current address and reserve a new one.
+
+## Importing already reserved addresses
+
+Addresses that are already reserved can be imported into terraform.
+
+Prepare a resource for the address.
+
+```
+$ cat ip.tf
+resource "glesys_ip" "example" {
+  address = "1.2.3.4"
+}
+```
+
+Import the resource by specifying its address.
+
+```
+$ terraform import glesys_ip.example 1.2.3.4
+glesys_ip.example: Importing from ID "1.2.3.4"...
+glesys_ip.example: Import prepared!
+  Prepared glesys_ip for import
+glesys_ip.example: Refreshing state... [id=1.2.3.4]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+## Changing reverse pointer records
+
+To manage reverse pointer records use the `ptr` attribute on the resource.
+Note that the `ptr` attribute *must* end with a dot `.` character.
+
+```
+$ cat ip.tf
+resource "glesys_ip" "example" {
+  datacenter = "Stockholm"
+  platform   = "KVM"
+  version    = 6
+  ptr        = "my.ptr."
+}
+```
+
+Due to how terraform internals work it is not possible to reset a reverse pointer by removing the attribute from the terraform file. Possible workarounds for resetting a reverse pointer value:
+
+1. Set the `ptr` attribute in terraform to what the default value would be. For example, for ip `1.2.3.4` the default value would be `1-2-3-4-static.glesys.net.`.
+1. Reset the reverse pointer value manually via the web interface or the [API](https://github.com/GleSYS/API/wiki/API-Documentation#ipresetptr). After resetting the reverse pointer manually, run `terraform refresh` to reflect the change in the terraform state.

--- a/examples/ip/example.tf
+++ b/examples/ip/example.tf
@@ -1,0 +1,10 @@
+resource "glesys_ip" "example" {
+  datacenter = "Stockholm"
+  platform   = "KVM"
+  version    = 4
+}
+
+resource "glesys_ip" "ptr_example" {
+  address = "1.2.3.4"
+  ptr     = "example.com."
+}

--- a/glesys/provider.go
+++ b/glesys/provider.go
@@ -34,6 +34,7 @@ func Provider() *schema.Provider {
 			"glesys_server":                   resourceGlesysServer(),
 			"glesys_objectstorage_instance":   resourceGlesysObjectStorageInstance(),
 			"glesys_objectstorage_credential": resourceGlesysObjectStorageCredential(),
+			"glesys_ip":                       resourceGlesysIP(),
 		},
 		// this will be used to configure the client to communicate with the API
 		ConfigureFunc: providerConfigure,

--- a/glesys/resource_glesys_ip.go
+++ b/glesys/resource_glesys_ip.go
@@ -1,0 +1,202 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/glesys/glesys-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGlesysIP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGlesysIPCreate,
+		Read:   resourceGlesysIPRead,
+		Update: resourceGlesysIPUpdate,
+		Delete: resourceGlesysIPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"broadcast": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cost": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"amount": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"currency": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"time_period": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"datacenter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"locked_to_account": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name_servers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"netmask": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"platforms": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"ptr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"reserved": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGlesysIPCreate(d *schema.ResourceData, m interface{}) error {
+	// Setup client to the API
+	client := m.(*glesys.Client)
+
+	address := d.Get("address").(string)
+	if address == "" {
+		// A reserved address has not been set
+		params := glesys.AvailableIPsParams{
+			DataCenter: d.Get("datacenter").(string),
+			Platform:   d.Get("platform").(string),
+			Version:    d.Get("version").(int),
+		}
+
+		// Get available ip addresses
+		ips, err := client.IPs.Available(context.Background(), params)
+		if err != nil {
+			return err
+		}
+
+		// Select the first available ip address for reservation
+		address = (*ips)[0].Address
+	}
+
+	ip, err := client.IPs.Reserve(context.Background(), address)
+	if err != nil {
+		return err
+	}
+
+	// Set the resource Id to IP address
+	d.SetId((*ip).Address)
+	return resourceGlesysIPRead(d, m)
+}
+
+func resourceGlesysIPRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*glesys.Client)
+
+	// Fetch updates about the IP
+	ip, err := client.IPs.Details(context.Background(), d.Id())
+	if err != nil {
+		fmt.Errorf("IP not found: %s", err)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("address", ip.Address)
+	d.Set("broadcast", ip.Broadcast)
+	d.Set("datacenter", ip.DataCenter)
+	d.Set("locked_to_account", ip.LockedToAccount)
+	d.Set("name_servers", ip.NameServers)
+	d.Set("netmask", ip.Netmask)
+	d.Set("platform", ip.Platform)
+	d.Set("platforms", ip.Platforms)
+	d.Set("reserved", ip.Reserved)
+	d.Set("server_id", ip.ServerID)
+	d.Set("ptr", ip.PTR)
+
+	cost := map[string]interface{}{
+		"amount":      ip.Cost.Amount,
+		"currency":    ip.Cost.Currency,
+		"time_period": ip.Cost.TimePeriod,
+	}
+	err = d.Set("cost", []map[string]interface{}{cost})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceGlesysIPUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*glesys.Client)
+
+	if d.HasChange("ptr") {
+		// There should be support here for resetting pointer records when they are zeroed.
+		// Because of how Optional+Computed attributes work it is not possible with the current SDK.
+		// More info in upstream issue #282: https://github.com/hashicorp/terraform-plugin-sdk/issues/282
+
+		ptr := d.Get("ptr").(string)
+		_, err := client.IPs.SetPTR(context.Background(), d.Id(), ptr)
+		if err != nil {
+			return fmt.Errorf("Error updating reverse pointer on IP: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceGlesysIPDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*glesys.Client)
+
+	err := client.IPs.Release(context.Background(), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/glesys/resource_glesys_ip_test.go
+++ b/glesys/resource_glesys_ip_test.go
@@ -1,0 +1,129 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/glesys/glesys-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccIP_basic(t *testing.T) {
+	name := "glesys_ip.test"
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testGlesysProviders,
+		CheckDestroy: testAccIPResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "glesys_ip" "test" {
+				    datacenter = "Stockholm"
+				    platform   = "KVM"
+				    version    = 4
+
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "datacenter", "Stockholm"),
+					resource.TestCheckResourceAttr(name, "platform", "KVM"),
+					resource.TestCheckResourceAttr(name, "version", "4"),
+					resource.TestCheckResourceAttrSet(name, "address"),
+					resource.TestCheckResourceAttrSet(name, "broadcast"),
+					resource.TestCheckResourceAttrSet(name, "cost.0.amount"),
+					resource.TestCheckResourceAttrSet(name, "cost.0.currency"),
+					resource.TestCheckResourceAttrSet(name, "cost.0.time_period"),
+					resource.TestCheckResourceAttrSet(name, "locked_to_account"),
+					resource.TestCheckResourceAttrSet(name, "name_servers.0"),
+					resource.TestCheckResourceAttrSet(name, "netmask"),
+					resource.TestCheckResourceAttrSet(name, "platforms.0"),
+					resource.TestCheckResourceAttrSet(name, "ptr"),
+					resource.TestCheckResourceAttrSet(name, "reserved"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIP_updatePTR(t *testing.T) {
+	name := "glesys_ip.test"
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testGlesysProviders,
+		CheckDestroy: testAccIPResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "glesys_ip" "test" {
+				    datacenter = "Stockholm"
+				    platform   = "KVM"
+				    version    = 4
+
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "datacenter", "Stockholm"),
+					resource.TestCheckResourceAttr(name, "platform", "KVM"),
+					resource.TestCheckResourceAttr(name, "version", "4"),
+					resource.TestCheckResourceAttrSet(name, "address"),
+					resource.TestCheckResourceAttrSet(name, "ptr"),
+					testAccIPDefaultPTRValue(name),
+				),
+			},
+			{
+				Config: `resource "glesys_ip" "test" {
+				    datacenter = "Stockholm"
+				    platform   = "KVM"
+				    version    = 4
+				    ptr        = "test.ptr."
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "datacenter", "Stockholm"),
+					resource.TestCheckResourceAttr(name, "platform", "KVM"),
+					resource.TestCheckResourceAttr(name, "version", "4"),
+					resource.TestCheckResourceAttr(name, "ptr", "test.ptr."),
+					resource.TestCheckResourceAttrSet(name, "address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIPResourceDestroy(s *terraform.State) error {
+	client := testGlesysProvider.Meta().(*glesys.Client)
+
+	for _, resource := range s.RootModule().Resources {
+		if resource.Type != "glesys_ip" {
+			continue
+		}
+
+		ip, err := client.IPs.Details(context.Background(), resource.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Unexpected error checking for released ip %s", err)
+		}
+
+		if ip.Reserved == "yes" {
+			return fmt.Errorf("IP %s is still reserved after destroy", resource.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccIPDefaultPTRValue(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", resourceName)
+		}
+
+		address := resource.Primary.Attributes["address"]
+		ptr := resource.Primary.Attributes["ptr"]
+
+		expectedPTR := fmt.Sprint(strings.ReplaceAll(address, ".", "-"), "-static.glesys.net.")
+		if ptr != expectedPTR {
+			return fmt.Errorf("Expected ptr value %s, got %s", expectedPTR, ptr)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Adds basic support for the IP service. Modeled the schema after the data type in the glesys-go library.

Only thing that does not work at the moment it resetting reverse pointers when removing that attribute in the terraform file, its due to how attributes that are optional and computed work. Any feedback on how that could be solved would be appreciated.