### PR TITLE
Fix #36 - Missing OSI credentials causing crash

### DIFF
--- a/glesys/resource_glesys_objectstorage_instance.go
+++ b/glesys/resource_glesys_objectstorage_instance.go
@@ -75,11 +75,14 @@ func resourceGlesysObjectStorageInstanceRead(d *schema.ResourceData, m interface
 	d.Set("datacenter", instance.DataCenter)
 	d.Set("description", instance.Description)
 	d.Set("created", instance.Created)
-	d.Set("accesskey", instance.Credentials[0].AccessKey)
 
-	_, secretkeyIsSet := d.GetOk("secretkey")
-	if !secretkeyIsSet {
-		d.Set("secretkey", instance.Credentials[0].SecretKey)
+	creds := instance.Credentials
+	if len(creds) > 0 {
+		d.Set("accesskey", creds[0].AccessKey)
+		_, secretkeyIsSet := d.GetOk("secretkey")
+		if !secretkeyIsSet {
+			d.Set("secretkey", creds[0].SecretKey)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When there are no credentials present for a object storage instance, the
read function will fail when reading a specific list position.

Adding a small len() check on the data returned fixes this.