### PR TITLE
Update README with local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,45 @@
 This is a early stage implementation for using Terraform and the GleSYS API.
 Please see https://github.com/glesys/glesys-go and https://github.com/GleSYS/API/wiki/API-Documentation for more information.
 
-## Installation / Local development
+## Installation
 
+### Using the terraform-provider-glesys
+
+In your Terraform configuration, add this. Then run `terraform init`
+
+```
+terraform {
+  required_providers {
+    glesys = {
+      source = "glesys/glesys"
+      # version = "0.4.2" # If you want to specify a certain release.
+    }
+  }
+}
+
+provider "glesys" {
+  # Configuration options
+}
+```
+
+`$ terraform init`
+
+### Run terraform
+
+Instead of hardcoding credentials into your terraform templates.
+Use environment variables for example.
+
+`GLESYS_USERID="CL12345" GLESYS_TOKEN="ABC12345678" terraform plan`
+
+## Local development
 ### Debian requirements
 
 - golang >= 1.15
 - git
 - make
-- terraform 0.12.x # Fetch the latest 0.12 version from https://releases.hashicorp.com/terraform/
+- terraform # Fetch the latest version from https://www.terraform.io/downloads
 
-#### install terraform
-
-```
-$ curl -O https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
-$ unzip terraform_0.12.29_linux_amd64.zip
-$ mv terraform ~/bin
-```
-
-### Setup terraform-provider-glesys
+### Setup terraform-provider-glesys for local development
 
 Clone the repo into a folder of your liking.
 
@@ -37,16 +58,25 @@ $ make
 go install
 go: finding github.com/hashicorp/terraform v0.12.9
 ...
-$ mkdir -p ~/.terraform.d/plugins
-$ ln -s ~s ~/go/bin/terraform-provider-glesys ~/.terraform.d/plugins/
+$ mkdir -p ~/.terraform.d/local_dev
+$ ln -s ~/go/bin/terraform-provider-glesys ~/.terraform.d/local_dev/
 ```
 
-### Run terraform
+Setup dev_overrides
 
-Instead of hardcoding credentials into your terraform templates.
-Use environment variables for example.
+Create a file `provider_overrides.tfrc` for example:
+```
+provider_installation {
+  dev_overrides {
+    "glesys/glesys" = "/home/myuser/.terraform.d/local_dev"
+  }
+  direct {}
+}
+```
 
-`GLESYS_USERID="CL12345" GLESYS_TOKEN="ABC12345678" terraform plan`
+Run terraform with environment variable `TF_CLI_CONFIG_FILE`
+
+`$ TF_CLI_CONFIG_FILE=/path/to/provider_overrides.tfrc terraform plan`
 
 ## Contribute
 


### PR DESCRIPTION
Add new instructions on how to use the provider with Terraform 1.x and when
doing local development.