### PR TITLE
Ae dnsdomain record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactor `glesys_server` Create and Delete to wait for attribute.
 - Fix typo in resource_glesys_server @norrland
 - Fix wrong header in docs/index.md @norrland
+- Update `glesys_domain_record` type to Required
 
 ## [0.4.6] - 2022-09-13
 ### Added

--- a/docs/resources/dnsdomain_record.md
+++ b/docs/resources/dnsdomain_record.md
@@ -15,11 +15,11 @@ description: |-
 - `data` (String) Record data field. Ex. `127.0.0.1`
 - `domain` (String) Domain name
 - `host` (String) Record host field. Ex. `www`
+- `type` (String) Record type. Must be one of `SOA`, `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SRV`, `URL` or `PTR`
 
 ### Optional
 
 - `ttl` (Number) Record TTL field
-- `type` (String) Record type. Ex. `A`, `AAAA`...
 
 ### Read-Only
 

--- a/glesys/resource_glesys_domain_record.go
+++ b/glesys/resource_glesys_domain_record.go
@@ -49,7 +49,7 @@ func resourceGlesysDNSDomainRecord() *schema.Resource {
 			"type": {
 				Description: "Record type. Ex. `A`, `AAAA`...",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    true,
 			},
 

--- a/glesys/resource_glesys_domain_record.go
+++ b/glesys/resource_glesys_domain_record.go
@@ -47,7 +47,7 @@ func resourceGlesysDNSDomainRecord() *schema.Resource {
 			},
 
 			"type": {
-				Description: "Record type. Ex. `A`, `AAAA`...",
+				Description: "Record type. Must be one of `SOA`, `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SRV`, `URL` or `PTR`",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,


### PR DESCRIPTION
Set `glesys_domain_record` field `type` to Required, as required by the API.