### PR TITLE
Add Importer to glesys_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
+### Changed
+- Support import in `glesys_server` @norrland (#66)
 
 ## [0.5.0] - 2022-09-21
 ### Changed

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -161,4 +161,9 @@ Required:
 - `password` (String)
 - `publickeys` (List of String) User SSH key(s), as a list. '["ssh-rsa abc...", "ssh-rsa foo..."]'
 - `username` (String)
-
+## Import
+Import is supported using the following syntax:
+```shell
+# glesys_server Import
+$ terraform import glesys_server.example kvm123456
+```

--- a/examples/resources/glesys_server/import.sh
+++ b/examples/resources/glesys_server/import.sh
@@ -1,0 +1,2 @@
+# glesys_server Import
+$ terraform import glesys_server.example kvm123456

--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -22,6 +22,10 @@ func resourceGlesysServer() *schema.Resource {
 
 		Description: "Create a new GleSYS virtual server.",
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),


### PR DESCRIPTION
Support importing existing glesys_server resources.

```shell
$ terraform import glesys_server.example kvm123456
```

Fixes #65