### PR TITLE
Fix KVM UUID Template name issue

### DIFF
--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -242,6 +242,9 @@ func getTemplate(original string, srv *glesys.ServerDetails) string {
 			return original
 		}
 	}
+	if original == srv.InitialTemplate.ID {
+		return original
+	}
 	return srv.Template
 }
 

--- a/glesys/resource_glesys_server_test.go
+++ b/glesys/resource_glesys_server_test.go
@@ -9,11 +9,12 @@ import (
 func Test_getTemplate(t *testing.T) {
 	srv := &glesys.ServerDetails{}
 	for _, tt := range []struct {
-		name         string
-		tfTemplate   string
-		readTemplate string
-		readTags     []string
-		want         string
+		name           string
+		tfTemplate     string
+		readTemplate   string
+		readTemplateID string
+		readTags       []string
+		want           string
 	}{
 		{
 			name:         "KVM_instance",
@@ -21,6 +22,14 @@ func Test_getTemplate(t *testing.T) {
 			readTemplate: "Ubuntu 20.04 LTS (Focal Fossa)",
 			readTags:     []string{"ubuntu", "ubuntu-lts", "ubuntu-20-04"},
 			want:         "ubuntu-20-04",
+		},
+		{
+			name:           "KVM_instance_UUID_Template",
+			tfTemplate:     "fc5d38f7-4c9d-4920-a3a0-3252f71fe2c5",
+			readTemplate:   "Ubuntu 20.04 LTS (Focal Fossa)",
+			readTemplateID: "fc5d38f7-4c9d-4920-a3a0-3252f71fe2c5",
+			readTags:       []string{"ubuntu", "ubuntu-lts", "ubuntu-20-04"},
+			want:           "fc5d38f7-4c9d-4920-a3a0-3252f71fe2c5",
 		},
 		{
 			name:         "VMware_instance",
@@ -34,6 +43,7 @@ func Test_getTemplate(t *testing.T) {
 			srv.Template = tt.readTemplate
 			srv.InitialTemplate.Name = tt.readTemplate
 			srv.InitialTemplate.CurrentTags = tt.readTags
+			srv.InitialTemplate.ID = tt.readTemplateID
 			if got := getTemplate(tt.tfTemplate, srv); got != tt.want {
 				t.Errorf("got: %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
When creating a KVM server resource using an UUID template ID as template name, the getTemplate helper could not match this to the ID in ServerDetails.InitialTemplate.

* Add if-statement to check InitialTemplate.ID
* Update glesys_server Tests

Fixes #78
