### PR TITLE
golangci action cache

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -19,5 +19,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
+          cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
- Checkout before setup
- Enable actions/setup-go cache
