### PR TITLE
Update resource_glesys_loadbalancer_target.go attribute

### DIFF
--- a/glesys/resource_glesys_loadbalancer_target.go
+++ b/glesys/resource_glesys_loadbalancer_target.go
@@ -61,7 +61,7 @@ func resourceGlesysLoadBalancerTarget() *schema.Resource {
 			"targetip": {
 				Description: "Target IP.",
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 			},
 
 			"weight": {


### PR DESCRIPTION
Set the `targetip` attribute as required.

Fixes #146