### PR TITLE
gh-action: use go stable and oldstable for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.22.x
-          - 1.23.x
+          - oldstable
+          - stable
 
     name: Go ${{ matrix.go }} Build
     steps:
@@ -52,8 +52,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.22.x
-          - 1.23.x
+          - oldstable
+          - stable
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Rather than updating the versions each release, let setup-go manage this by using the
stable and oldstable aliases
