### PR TITLE
Add glesys_server attribute `keepip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Implement datasource `glesys_ip`
 ### Changed
+- glesys_server attribute `keepip` to control whether to keep or release IP from project on server delete.
 
 ## 0.16.1 - 2026-02-26
 ### Added

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -193,6 +193,7 @@ Examples can be found in the [GleSYS API - Cloud config documentation](https://g
 - `ipv4_address` (String) Server IPv4 address, set `none` to disable IP allocation
 - `ipv6_address` (String) Server IPv6 address, set `none` to disable IP allocation
 - `password` (String) Server root password, VMware only
+- `keepip` (Boolean) Used to set Keep IP when deleting server. If true, the IP(s) will still be reserved in your Glesys project after server deletion.
 - `platform` (String) Server virtualisation platform, `KVM` or `VMware`
 - `primary_networkadapter_network` (String) (VMware) Set the network for the primary network adapter.
 - `publickey` (String)

--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -88,6 +88,12 @@ func resourceGlesysServer() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"keepip": {
+				Description: "Used to set Keep IP when deleting server. If true, the IP(s) will still be reserved in your Glesys project after server deletion.",
+				Default:     false,
+				Optional:    true,
+				Type:        schema.TypeBool,
+			},
 			"memory": {
 				Description: "Server RAM setting",
 				Type:        schema.TypeInt,
@@ -311,7 +317,6 @@ func resourceGlesysServerCreate(ctx context.Context, d *schema.ResourceData, m i
 	srv.Users = usersList
 
 	host, err := client.Servers.Create(ctx, *srv)
-
 	if err != nil {
 		return diag.Errorf("error creating server: %+v", err)
 	}
@@ -503,13 +508,11 @@ func resourceGlesysServerDelete(ctx context.Context, d *schema.ResourceData, m i
 
 	// Call waitForServerAttribute to make sure the server isn't locked before deleting it.
 	_, err := waitForServerAttribute(ctx, d, "false", []string{"true"}, "islocked", m)
-
 	if err != nil {
 		return diag.Errorf("Error waiting for server to be unlocked for destroy (%s): %s", d.Id(), err)
 	}
 	// destroy the server, don't keep the ip.
-	err = client.Servers.Destroy(ctx, d.Id(), glesys.DestroyServerParams{KeepIP: false})
-
+	err = client.Servers.Destroy(ctx, d.Id(), glesys.DestroyServerParams{KeepIP: d.Get("keepip").(bool)})
 	if err != nil {
 		return diag.Errorf("Error deleting instance (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
When deleting a server in glesys api. The user can choose to keep the IP
reserved on the project. This adds the option on a `glesys_server` to
not release the IP from the project in case it's managed by a
`glesys_ip` resource for example.

Fixes #57
