### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
+### Changed
+
+## 0.17.0 - 2026-07-06
+### Added
 - Implement datasource `glesys_ip`
 ### Changed
 - glesys_server attribute `keepip` to control whether to keep or release IP from project on server delete.
+- glesys_networkadapter Wait for server to be unlocked before creating new adapters
+- glesys_server Make the root and user password values sensitive.
 
 ## 0.16.1 - 2026-02-26
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     glesys = {
       source  = "glesys/glesys"
-      version = "~> 0.16.1"
+      version = "~> 0.17.0"
     }
   }
 }

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -192,8 +192,8 @@ Examples can be found in the [GleSYS API - Cloud config documentation](https://g
 - `description` (String) Server description
 - `ipv4_address` (String) Server IPv4 address, set `none` to disable IP allocation
 - `ipv6_address` (String) Server IPv6 address, set `none` to disable IP allocation
-- `password` (String) Server root password, VMware only
 - `keepip` (Boolean) Used to set Keep IP when deleting server. If true, the IP(s) will still be reserved in your Glesys project after server deletion.
+- `password` (String, Sensitive) Server root password, VMware only
 - `platform` (String) Server virtualisation platform, `KVM` or `VMware`
 - `primary_networkadapter_network` (String) (VMware) Set the network for the primary network adapter.
 - `publickey` (String)
@@ -227,7 +227,7 @@ Required:
 
 Optional:
 
-- `password` (String)
+- `password` (String, Sensitive)
 
 
 <a id="nestedatt--network_adapters"></a>

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     glesys = {
       source  = "glesys/glesys"
-      version = "~> 0.16.1"
+      version = "~> 0.17.0"
     }
   }
 }

--- a/glesys/config.go
+++ b/glesys/config.go
@@ -14,7 +14,7 @@ type Config struct {
 
 // Client - Setup new glesys client
 func (c *Config) Client() (*glesys.Client, error) {
-	client := glesys.NewClient(c.UserID, c.Token, "tf-glesys/0.16.1")
+	client := glesys.NewClient(c.UserID, c.Token, "tf-glesys/0.17.0")
 
 	err := client.SetBaseURL(c.APIEndpoint)
 	if err != nil {


### PR DESCRIPTION
* New attributes `keepip` in glesys_server
* Changed sensitive values in glesys_server password fields.
* Wait for server locked status before creating glesys_networkadapters
* Add missing docs/examples
